### PR TITLE
Adding support for Cordova v7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "cordova-useragent",
+  "version": "1.0.0",
+  "description": "Cordova plugin for reading/changing the user agent of WebView client",
+  "cordova": {
+    "id": "im.ltdev.cordova.UserAgent",
+    "platforms": [
+      "android",
+      "ios"
+    ]
+  },
+  "keywords": [
+    "cordova",
+    "ecosystem:cordova",
+    "useragent"
+  ]
+}


### PR DESCRIPTION
Starting with Cordova 7.0, plugins are required to include `package.json`

More info: https://cordova.apache.org/news/2017/05/04/cordova-7.html